### PR TITLE
Add ignoring Node.js in `countryWasIgnored` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,11 +90,15 @@ const CHECKS = {
   },
 
   countryWasIgnored(ast, browsers) {
+    // The Node.js is not in the Can I Use db
+    let browsersWithStats = browsers.filter(i => !i.startsWith('node'))
+    if (!browsersWithStats.length) return false
+
     let coverage
     let countries = []
     let tx = 0
     for (let code in COUNTRIES_10M) {
-      coverage = browserslist.coverage(browsers, code)
+      coverage = browserslist.coverage(browsersWithStats, code)
       tx = 100 / getTotalCoverage(browserslist.usage[code])
       if (coverage * tx < COUNTRIES_MIN_COVERAGE) {
         countries.push(COUNTRIES_10M[code])

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -55,6 +55,7 @@ test('reports limited-browsers problem', () => {
 test('reports country-was-ignored problem', () => {
   hasProblem(lint(['last 2 versions']), 'countryWasIgnored')
   doesNotHaveProblem(lint(['last 100 versions']), 'countryWasIgnored')
+  doesNotHaveProblem(lint(['maintained node versions']), 'countryWasIgnored')
 })
 
 test('formats report', () => {


### PR DESCRIPTION
Node.js is not in the Can I Use db and has not audience coverage stats.

**Bug**
![image](https://user-images.githubusercontent.com/22644149/186014899-0e09ec6f-5b99-40a9-85a2-616cadb02016.png)

---

I added ignoring Node.js in rule `countryWasIgnored`.

Now the linter **does not report** problems in the queries:
- `maintained node versions` (add to tests)
- `node 18`
- `>0% or Node > 0`

For query `>2% or  maintained node versions` we report a problem