### PR TITLE
Filter out `popularity` type queries in `countryWasIgnored` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ const COUNTRIES_10M = {
   UG: 'Uganda',
   BE: 'Belgium'
 }
+const MIN_WORLD_USAGE = 0.3
 
 function getTotalCoverage(data) {
   let total = 0
@@ -124,7 +125,14 @@ const CHECKS = {
       }
       return {
         message: msg + concat(names) + ' regions',
-        fixed: '>0.3%, ' + ast.map(query => query.query).join(', ')
+        fixed:
+          '>' +
+          MIN_WORLD_USAGE +
+          '%, ' +
+          ast
+            .filter(query => query.type !== 'popularity')
+            .map(query => query.query)
+            .join(', ')
       }
     } else {
       return false

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -61,6 +61,11 @@ test('reports countryWasIgnored problem', () => {
     'countryWasIgnored',
     '>0.3%, last 1 versions'
   )
+  hasProblem(
+    lint(['>2%, >0.9%, last 1 versions']),
+    'countryWasIgnored',
+    '>0.3%, last 1 versions'
+  )
   doesNotHaveProblem(lint(['last 100 versions']), 'countryWasIgnored')
   doesNotHaveProblem(lint(['maintained node versions']), 'countryWasIgnored')
 })


### PR DESCRIPTION
If I understand correctly auto-fix for `countryWasIgnored` rule should replace all `popularity` type queries with single `>0.3%` value