### PR TITLE
Remove extra `,` in a fixed query with a single `popularity` expression

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,16 +124,17 @@ const CHECKS = {
       if (names.length > 5) {
         names = names.slice(0, 5).concat([`${countries.length - 5} more`])
       }
+
+      let fixedArray = [
+        `>${MIN_WORLD_USAGE}%`,
+        ...ast
+          .filter(query => query.type !== 'popularity')
+          .map(query => query.query)
+      ]
+
       return {
         message: msg + concat(names) + ' regions',
-        fixed:
-          '>' +
-          MIN_WORLD_USAGE +
-          '%, ' +
-          ast
-            .filter(query => query.type !== 'popularity')
-            .map(query => query.query)
-            .join(', ')
+        fixed: fixedArray.join(', ')
       }
     } else {
       return false

--- a/index.js
+++ b/index.js
@@ -125,16 +125,14 @@ const CHECKS = {
         names = names.slice(0, 5).concat([`${countries.length - 5} more`])
       }
 
-      let fixedArray = [
-        `>${MIN_WORLD_USAGE}%`,
-        ...ast
-          .filter(query => query.type !== 'popularity')
-          .map(query => query.query)
-      ]
-
       return {
         message: msg + concat(names) + ' regions',
-        fixed: fixedArray.join(', ')
+        fixed: [
+          `>${MIN_WORLD_USAGE}%`,
+          ...ast
+            .filter(query => query.type !== 'popularity')
+            .map(query => query.query)
+        ].join(', ')
       }
     } else {
       return false

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,6 +66,11 @@ test('reports countryWasIgnored problem', () => {
     'countryWasIgnored',
     '>0.3%, last 1 versions'
   )
+  hasProblem(
+    lint(['>5%']),
+    'countryWasIgnored',
+    '>0.3%'
+  )
   doesNotHaveProblem(lint(['last 100 versions']), 'countryWasIgnored')
   doesNotHaveProblem(lint(['maintained node versions']), 'countryWasIgnored')
 })


### PR DESCRIPTION

![image](https://github.com/browserslist/lint/assets/22644149/56517e35-793d-479f-b4cc-4a970ed37b1b)
