### PR TITLE
feat: add a pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Rules:
        alt="Sponsored by Evil Martians" width="236" height="54">
 </a>
 
+## Pre-Commit Hook
+
+This project is also available as a pre-commit hook. Please add the following to your pre-commit configuration.
+
+```yaml
+repos:
+    - repo: https://github.com/browserslist/lint
+      id: browserslist-lint
+```
 
 ## JS API
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ Rules:
 
 ## Pre-Commit Hook
 
-This project is also available as a pre-commit hook. Please add the following to your pre-commit configuration.
+This project is also available as a [pre-commit hook](https://pre-commit.com/). Please add the following to your pre-commit configuration.
 
 ```yaml
 repos:
-    - repo: https://github.com/browserslist/lint
-      id: browserslist-lint
+  - repo: https://github.com/browserslist/lint
+    id: browserslist-lint
 ```
 
 ## JS API

--- a/pre-commit-hooks.yaml
+++ b/pre-commit-hooks.yaml
@@ -2,15 +2,15 @@
 - id: browserslist-lint
   name: Validate Browserslist Configuration
   # Command to execute the linter using npx for local installation
-  entry: npx browserslist-linter
+  entry: npx browserslist-lint
   # Specify the language for the hook; 'node' is used for npm-based tools
   language: node
   # Regular expression to match files that should trigger the hook
   # The hook will run if `.browserslistrc` or `package.json` is modified
-  files: ^(\.browserslistrc|package\.json)$
+  files: (\.browserslistrc|package\.json)$
   # Disable passing filenames as arguments since the linter inspects its own targets
   pass_filenames: false
   # Run the hook only when relevant files are modified, not always
   always_run: false
   # Description of the hook to inform users about its purpose
-  description: Validate Browserslist configuration using browserslist-linter.
+  description: Validate Browserslist configuration using browserslist-lint.

--- a/pre-commit-hooks.yaml
+++ b/pre-commit-hooks.yaml
@@ -1,0 +1,16 @@
+# Define the hooks available in this repository
+- id: browserslist-lint
+  name: Validate Browserslist Configuration
+  # Command to execute the linter using npx for local installation
+  entry: npx browserslist-linter
+  # Specify the language for the hook; 'node' is used for npm-based tools
+  language: node
+  # Regular expression to match files that should trigger the hook
+  # The hook will run if `.browserslistrc` or `package.json` is modified
+  files: ^(\.browserslistrc|package\.json)$
+  # Disable passing filenames as arguments since the linter inspects its own targets
+  pass_filenames: false
+  # Run the hook only when relevant files are modified, not always
+  always_run: false
+  # Description of the hook to inform users about its purpose
+  description: Validate Browserslist configuration using browserslist-linter.


### PR DESCRIPTION
This pull request introduces a pre-commit hook for validating Browserslist configurations. The most important changes include the addition of a configuration file for the pre-commit hooks. There are also relevant additions to the `README.md`.

Pre-commit hook addition:

* [`pre-commit-hooks.yaml`](diffhunk://#diff-a0a99f979438e06c762f520bf3cce54eb088f4b92c8e033645a466d967a862f2R1-R16): Defined a new hook, `browserslist-lint`, to validate Browserslist configurations using `npx browserslist-linter`. This hook is triggered by changes to `.browserslistrc` or `package.json`.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R28-R36): Added a section on the pre-commit hook, including instructions on how to add it to the pre-commit configuration.